### PR TITLE
dynamic ht-include working in ht-repeat

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-template",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "description": "Angular-Like HTML Template",
   "main": "index.js",
   "scripts": {
@@ -17,8 +17,7 @@
   "license": "MIT",
   "dependencies": {
     "cheerio": "^0.19.0",
-    "js-template": "~0.1.3",
-    "lodash": "^3.2.0"
+    "js-template": "~0.1.3"
   },
   "devDependencies": {
     "gulp": "~3.8.5",

--- a/spec/small.html
+++ b/spec/small.html
@@ -1,0 +1,1 @@
+<span>{{item.content}}</span>

--- a/spec/spec.js
+++ b/spec/spec.js
@@ -70,13 +70,24 @@ assert(ht("<div ht-include=\"item.template\"></div>", {item:{template:'file2.htm
  * file does not exist, so it will print out as html, the file name
  *******************************************************************/
 console.log(11);
-assert(ht("<div ht-repeat=\"item in items\"><div ht-include=\"item.template\"></div>", {items:[{template:'file3.html'}, {template:'file4.html'}]}).match(/<div>.*file3.html<\/div>/));
+var exampleResult = ht("<div ht-repeat=\"item in items\"><div ht-include=\"item.template\"></div>", {items:[{template:'file3.html'}, {content:'foo', template:'spec/small.html'}]});
+assert(exampleResult.match(/<div>.*file3.html<\/div>/));
+assert(exampleResult.match(/<span>foo<\/span>/));
+
+/*******************************************************************
+ * `ht-include` expression test, passed as property in a nested repeat with key value
+ * file does not exist, so it will print out as html, the file name
+ *******************************************************************/
+console.log(12);
+var exampleResult2 = ht("<div ht-repeat=\"parentItem in items\"><div ht-repeat=\"(key, item) in parentItem.items\"><div ht-include=\"item.template\"></div>", {items:[{items:[{template:'file3.html'}]},{items:[{content:'foo', template:'spec/small.html'}]}]});
+assert(exampleResult2.match(/<div>.*file3.html<\/div>/));
+assert(exampleResult2.match(/<span>foo<\/span>/));
 
 
 /*******************************************************************
  * jsdoc template test
  *******************************************************************/
-console.log(12);
+console.log(13);
 var output = ht("spec/layout.html",
   {nav:[], children:[{members:[], functions:[]}]},
   {jsMode:false, prefix:'ng'});

--- a/spec/spec.js
+++ b/spec/spec.js
@@ -45,25 +45,38 @@ assert.equal("<li>a1</li><li>b2</li><li>c3</li>",
   ));
 
 /*******************************************************************
- * `ht-include` expression test
+ * `ht-include` expression test, passed as non existing property for backwards compatibility
  * file does not exist, so it will print out as html, the file name
  *******************************************************************/
 console.log(8);
 assert(ht("<div ht-include=\"file1.html\"></div>", {}).match(/<div>.*file1.html<\/div>/));
 
 /*******************************************************************
- * `ht-include` expression test
+ * `ht-include` expression test, passed as string
  * file does not exist, so it will print out as html, the file name
  *******************************************************************/
 console.log(9);
+assert(ht("<div ht-include=\"'file1.html'\"></div>", {}).match(/<div>.*file1.html<\/div>/));
+
+/*******************************************************************
+ * `ht-include` expression test, passed as property
+ * file does not exist, so it will print out as html, the file name
+ *******************************************************************/
+console.log(10);
 assert(ht("<div ht-include=\"item.template\"></div>", {item:{template:'file2.html'}}).match(/<div>.*file2.html<\/div>/));
 
+/*******************************************************************
+ * `ht-include` expression test, passed as property in a repeat
+ * file does not exist, so it will print out as html, the file name
+ *******************************************************************/
+console.log(11);
+assert(ht("<div ht-repeat=\"item in items\"><div ht-include=\"item.template\"></div>", {items:[{template:'file3.html'}, {template:'file4.html'}]}).match(/<div>.*file3.html<\/div>/));
 
 
 /*******************************************************************
  * jsdoc template test
  *******************************************************************/
-console.log(10);
+console.log(12);
 var output = ht("spec/layout.html",
   {nav:[], children:[{members:[], functions:[]}]},
   {jsMode:false, prefix:'ng'});


### PR DESCRIPTION
After creating initial pull request I didn't realize/test that it doesn't work within ht-repeat - this PR fixes just that.

Included template now also has access to current context, that is the key and value variables created by the loop. Deepest values will take presence. 

I also added additional unit tests and made sure that nothing breaks.
